### PR TITLE
Added .upcase to plain_text split

### DIFF
--- a/lib/caesar.rb
+++ b/lib/caesar.rb
@@ -1,14 +1,14 @@
 # Caesar Cipher
-# 
+#
 # encode/decode any string using the Caesar Cipher method.
-# 
+#
 # Usage:
 #   Caesar.encode('A', 'CAESAR') #=> "CAESAR"
 #   Caesar.encode('R', 'CAESAR') #=> "TRVJRI"
 #
 #   Caesar.decode('A', 'CAESAR') #=> "CAESAR"
-#   Caesar.decode('R', 'TRVJRI') #=> "CAESAR" 
-# 
+#   Caesar.decode('R', 'TRVJRI') #=> "CAESAR"
+#
 
 module Caesar
   A_OFFSET = 65 #'A'.unpack('C').first
@@ -17,7 +17,7 @@ module Caesar
   def Caesar.encode(key, plain_text)
     key_offset = key.upcase.unpack('C').first
 
-    cipher_text = plain_text.upcase.split('').collect do |letter| 
+    cipher_text = plain_text.upcase.split('').collect do |letter|
       cipher_letter = (letter.unpack('C').first + key_offset - A_OFFSET)
       if cipher_letter > Z_OFFSET
         cipher_letter -= ( Z_OFFSET - A_OFFSET + 1 )
@@ -31,7 +31,7 @@ module Caesar
   def Caesar.decode(key, cipher_text)
     key_offset = key.upcase.unpack('C').first
 
-    plain_text = cipher_text.split('').collect do |cipher_letter|
+    plain_text = cipher_text.upcase.split('').collect do |cipher_letter|
       if !('A'..'Z').include?(cipher_letter)
         cipher_letter
       else
@@ -48,4 +48,3 @@ module Caesar
     return plain_text.join
   end
 end
-


### PR DESCRIPTION
Hey, we were using this for a class project and noticed that the decode method didn't correctly handle mixed-case input. Added .upcase as used in encode method to remedy. Cheers!
